### PR TITLE
docs(codeofconduct): add code of conduct file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,117 @@
 # CODE OF CONDUCT
+
+> This project is committed to providing a welcoming, respectful, and collaborative environment for everyone who participates. Whether you're reporting an issue, improving documentation, submitting code, or participating in discussions, you are expected to contribute in a way that supports a positive and inclusive community.
+
+---
+
+# Our Pledge
+
+We as contributors and maintainers pledge to make participation in our community a respectful, welcoming, and harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+---
+
+# Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people.
+* Being respectful of differing opinions, viewpoints, and experiences.
+* Giving and gracefully accepting constructive feedback.
+* Taking responsibility for mistakes, apologizing when appropriate, and learning from the experience.
+* Focusing on what is best for the community and the project.
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances.
+* Trolling, insulting or derogatory comments, and personal or political attacks.
+* Public or private harassment.
+* Publishing others' private information without their explicit permission.
+* Any other conduct that could reasonably be considered inappropriate in a professional community.
+
+---
+
+# Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing this Code of Conduct.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, documentation, issues, discussions, pull requests, and other contributions that are not aligned with this Code of Conduct.
+
+When appropriate, maintainers will communicate the reasons for moderation decisions respectfully and transparently.
+
+---
+
+# Scope
+
+This Code of Conduct applies within all project spaces, including but not limited to:
+
+* GitHub Issues
+* Pull Requests
+* Discussions
+* Project documentation
+* Community communication channels
+
+It also applies when an individual is officially representing the project in public spaces.
+
+---
+
+# Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer through the project's GitHub repository.
+
+All reports will be reviewed promptly and fairly. Every reasonable effort will be made to protect the privacy and security of those involved.
+
+---
+
+# Enforcement Guidelines
+
+Project maintainers will follow these general community impact guidelines when determining the appropriate response to violations.
+
+## 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome.
+
+**Consequence:** A private, written warning explaining why the behavior was inappropriate and what is expected in the future.
+
+---
+
+## 2. Warning
+
+**Community Impact:** A violation through a single incident or a series of actions.
+
+**Consequence:** A formal warning. Continued behavior may result in temporary restrictions from participating in the project.
+
+---
+
+## 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from interacting with the project or community.
+
+---
+
+## 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violating the Code of Conduct or engaging in severe misconduct such as harassment or discrimination.
+
+**Consequence:** Permanent removal from participation in the project community.
+
+---
+
+# Attribution
+
+This Code of Conduct is adapted from the **Contributor Covenant**, version 2.1.
+
+For more information about the Contributor Covenant, visit:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+---
+
+# Thank You
+
+Thank you for helping make **mern-enterprise-starter** a welcoming, professional, and collaborative open-source project.
+
+A healthy community is built through respectful communication, thoughtful collaboration, and a shared commitment to continuous learning.


### PR DESCRIPTION
## Summary

Add a Code of Conduct to establish community expectations and promote a welcoming, respectful, and collaborative environment for all contributors.

## Motivation

Adopting a Code of Conduct helps set clear behavioral expectations, encourages constructive collaboration, and aligns the repository with widely accepted open-source community practices.

## Changes

* Add `CODE_OF_CONDUCT.md`
* Adopt the Contributor Covenant v2.1
* Configure the enforcement contact to use the project's GitHub repository

## Impact

* Establishes community participation guidelines
* Improves repository governance
* No impact on application functionality

## Documentation

* [x] Repository governance updated
* [ ] No additional documentation changes required

## Testing

Not applicable.

This change introduces community governance documentation only.
