### PR TITLE
docs(security): add security file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,92 @@
 # SECURITY
+
+> Security is a shared responsibility. This document explains how to responsibly report security vulnerabilities in **mern-enterprise-starter** and what to expect after submitting a report.
+
+---
+
+# Security Philosophy
+
+Security is considered an integral part of software quality throughout this project.
+
+Potential vulnerabilities should be reported responsibly and privately to help protect users while allowing sufficient time to investigate, validate, and resolve the issue before public disclosure.
+
+---
+
+# Supported Versions
+
+Security fixes are provided for supported releases of the project.
+
+| Version        | Supported |
+| -------------- | :-------: |
+| Latest Release |     ✅     |
+| Older Releases |     ❌     |
+
+As the project evolves, this policy may be updated to specify supported release ranges.
+
+---
+
+# Reporting a Vulnerability
+
+If you discover a potential security vulnerability, please **do not open a public GitHub Issue**.
+
+Instead, use **GitHub Private Vulnerability Reporting** to submit the report.
+
+Private reporting allows the maintainer to investigate and resolve the issue before details become publicly available.
+
+---
+
+# What to Include
+
+Providing the following information helps reproduce and investigate the issue efficiently:
+
+* A clear description of the vulnerability.
+* Steps to reproduce the issue.
+* The affected version or commit.
+* The potential security impact.
+* Proof of concept, screenshots, or logs (if applicable).
+* Any suggested mitigation or fix (optional).
+
+Reports with sufficient detail are easier to investigate and resolve.
+
+---
+
+# Response Process
+
+After receiving a report, the maintainer will:
+
+1. Acknowledge receipt of the report.
+2. Investigate and validate the reported issue.
+3. Determine the severity and potential impact.
+4. Develop and test an appropriate fix.
+5. Coordinate disclosure when the issue has been resolved.
+
+The maintainer will make every reasonable effort to keep the reporter informed throughout the process.
+
+---
+
+# Responsible Disclosure
+
+Please allow a reasonable amount of time for the vulnerability to be investigated and addressed before publicly disclosing any details.
+
+Coordinated disclosure helps protect users while a fix is being prepared and released.
+
+---
+
+# Security Best Practices
+
+Contributors are encouraged to help maintain a secure project by following these practices:
+
+* Never commit secrets, credentials, or API keys.
+* Keep dependencies up to date.
+* Review dependency updates before merging.
+* Validate and sanitize external input.
+* Follow the principle of least privilege.
+* Report suspected vulnerabilities responsibly.
+
+Security is everyone's responsibility and should be considered throughout the software development lifecycle.
+
+---
+
+# Thank You
+
+Thank you for helping improve the security of **mern-enterprise-starter**.


### PR DESCRIPTION
## Summary

Add a security policy describing how vulnerabilities should be reported and how security issues are handled within the project.

## Motivation

A documented security policy provides contributors and security researchers with a clear process for responsibly reporting vulnerabilities while protecting users through coordinated disclosure.

## Changes

* Add `SECURITY.md`
* Document the project's security philosophy
* Define supported versions
* Adopt GitHub Private Vulnerability Reporting
* Describe the vulnerability reporting and disclosure process
* Provide security best practices for contributors

## Impact

* Establishes the repository's security policy
* Improves project governance
* No impact on application functionality

## Documentation

* [x] Repository governance updated
* [ ] No additional documentation changes required

## Testing

Not applicable.

This change introduces repository governance documentation only.
