### PR TITLE
docs(changelog): add change log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Each release represents a stable milestone in the evolution of the repository.
 
 ---
 
-## [0.1.0] - 2026-07-31
+## [0.1.0] - 2026-08-01
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,85 @@
-# CHANGE LOG
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on **Keep a Changelog**, and this project follows **Semantic Versioning**.
+
+## Versioning
+
+Project releases are aligned with the milestones defined in `ROADMAP.md`.
+
+Each release represents a stable milestone in the evolution of the repository.
+
+---
+
+## [Unreleased]
+
+### Added
+
+*No unreleased changes.*
+
+---
+
+## [0.1.0] - 2026-07-31
+
+### Added
+
+#### Repository Foundation
+
+* Initial repository structure
+* Repository documentation
+* Pull request template
+* MIT License
+
+#### Documentation
+
+* `README.md`
+* `PROJECT.md`
+* `PHILOSOPHY.md`
+* `DESIGN.md`
+* `ROADMAP.md`
+* `CONTRIBUTING.md`
+
+#### Engineering Workflow
+
+* Branching strategy
+* Pull request workflow
+* Code review guidelines
+* Release strategy
+* Repository governance
+
+### Changed
+
+*None.*
+
+### Deprecated
+
+*None.*
+
+### Removed
+
+*None.*
+
+### Fixed
+
+*None.*
+
+### Security
+
+* Added the MIT License to clearly define the project's licensing terms.
+
+```
+
+---
+
+### Maintaining the Changelog
+
+The changelog should summarize **notable changes**, not every commit.
+
+When preparing a new release:
+
+1. Record new changes under the **Unreleased** section.
+2. Move those entries into a new version section when the release is published.
+3. Create a fresh **Unreleased** section for future development.
+
+```


### PR DESCRIPTION
## Summary

Prepare the repository for the `v0.1.0 – Documentation Foundation` release by finalizing the changelog.

## Motivation

The project documentation and repository governance are now complete. This change updates the changelog to record the first official release and establish the release history for future versions.

## Changes

* Finalize the `v0.1.0` release entry in `CHANGELOG.md`
* Replace the `Unreleased` placeholder with the official release section
* Record the documentation foundation milestone

## Impact

* Marks the completion of Phase 1 – Documentation Foundation
* Establishes the project's release history
* No impact on application functionality

## Documentation

* [x] CHANGELOG updated
* [x] Release documentation prepared

## Testing

Not applicable.

This change prepares the repository for the first official release (`v0.1.0`) and does not introduce any functional changes.
